### PR TITLE
feature recovery

### DIFF
--- a/navigation/go_forward_recovery/CMakeLists.txt
+++ b/navigation/go_forward_recovery/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(go_forward_recovery)
+
+find_package(catkin REQUIRED
+        COMPONENTS
+            cmake_modules
+            roscpp
+            tf
+            costmap_2d
+            nav_core
+            pluginlib
+            base_local_planner
+        )
+
+find_package(Eigen REQUIRED)
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+    ${EIGEN_INCLUDE_DIRS}
+)
+add_definitions(${EIGEN_DEFINITIONS})
+
+catkin_package(
+    INCLUDE_DIRS include
+    LIBRARIES go_forward_recovery
+    CATKIN_DEPENDS
+        roscpp
+        pluginlib
+)
+
+add_library(go_forward_recovery src/go_forward_recovery.cpp)
+target_link_libraries(go_forward_recovery ${catkin_LIBRARIES})
+
+install(TARGETS go_forward_recovery
+       ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+       LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+       )
+
+install(FILES recovery_plugin.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+

--- a/navigation/go_forward_recovery/include/go_forward_recovery/go_forward_recovery.h
+++ b/navigation/go_forward_recovery/include/go_forward_recovery/go_forward_recovery.h
@@ -1,0 +1,83 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Copyright (c) 2017, Ryo Okazaki.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: Eitan Marder-Eppstein
+*         Ryo Okazaki
+*********************************************************************/
+#ifndef GO_FORWARD_RECOVERY_H_
+#define GO_FORWARD_RECOVERY_H_
+#include <nav_core/recovery_behavior.h>
+#include <costmap_2d/costmap_2d_ros.h>
+#include <tf/transform_listener.h>
+#include <ros/ros.h>
+#include <base_local_planner/costmap_model.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Point.h>
+#include <angles/angles.h>
+#include <sensor_msgs/LaserScan.h>
+
+#define RANGE_MAX 5.6
+
+namespace go_forward_recovery{
+  class GoForwardRecovery : public nav_core::RecoveryBehavior {
+    public:
+      GoForwardRecovery();
+
+  void initialize(std::string name, tf2_ros::Buffer*,
+                  costmap_2d::Costmap2DROS*, costmap_2d::Costmap2DROS* local_costmap);
+
+      void runBehavior();
+
+      ~GoForwardRecovery();
+
+    private:
+      costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
+      costmap_2d::Costmap2D costmap_;
+      std::string name_;
+      tf::TransformListener* tf_;
+      ros::NodeHandle n;
+      ros::Publisher vel_pub;
+      ros::Subscriber scan_sub;
+      geometry_msgs::Twist cmd_vel;
+      bool initialized_;
+      base_local_planner::CostmapModel* world_model_;
+      double null_check(double target);
+      void scanCallback(const sensor_msgs::LaserScan::ConstPtr& msg);
+      int sub_n, sub_flag;
+  };
+};
+#endif  

--- a/navigation/go_forward_recovery/include/go_forward_recovery/go_forward_recovery.h
+++ b/navigation/go_forward_recovery/include/go_forward_recovery/go_forward_recovery.h
@@ -42,15 +42,10 @@
 #define GO_FORWARD_RECOVERY_H_
 #include <nav_core/recovery_behavior.h>
 #include <costmap_2d/costmap_2d_ros.h>
-#include <tf/transform_listener.h>
-#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
 #include <base_local_planner/costmap_model.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Point.h>
-#include <angles/angles.h>
 #include <sensor_msgs/LaserScan.h>
 
-#define RANGE_MAX 5.6
 
 namespace go_forward_recovery{
   class GoForwardRecovery : public nav_core::RecoveryBehavior {
@@ -65,14 +60,8 @@ namespace go_forward_recovery{
       ~GoForwardRecovery();
 
     private:
-      costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
+      costmap_2d::Costmap2DROS* local_costmap_;
       costmap_2d::Costmap2D costmap_;
-      std::string name_;
-      tf::TransformListener* tf_;
-      ros::NodeHandle n;
-      ros::Publisher vel_pub;
-      ros::Subscriber scan_sub;
-      geometry_msgs::Twist cmd_vel;
       bool initialized_;
       base_local_planner::CostmapModel* world_model_;
       double null_check(double target);

--- a/navigation/go_forward_recovery/package.xml
+++ b/navigation/go_forward_recovery/package.xml
@@ -1,0 +1,39 @@
+<package>
+    <name>go_forward_recovery</name>
+    <version>1.12.13</version>
+    <description>
+
+        This package provides a recovery behavior for the navigation stack that attempts to clear space by performing going forward of the robot.
+
+    </description>
+    <author>Eitan Marder-Eppstein</author>
+    <author>contradict@gmail.com</author>
+    <author>Ryo Okazaki</author>
+    <maintainer email="ryo.okazaki.0929@gmail.com">Ryo Okazaki</maintainer>
+    <license>MIT</license>
+    <url></url>
+
+    <buildtool_depend>catkin</buildtool_depend>
+
+    <build_depend>cmake_modules</build_depend>
+    <build_depend>roscpp</build_depend>
+    <build_depend>tf</build_depend>
+    <build_depend>costmap_2d</build_depend>
+    <build_depend>nav_core</build_depend>
+    <build_depend>pluginlib</build_depend>
+    <build_depend>eigen</build_depend>
+    <build_depend>base_local_planner</build_depend>
+
+    <run_depend>roscpp</run_depend>
+    <run_depend>tf</run_depend>
+    <run_depend>costmap_2d</run_depend>
+    <run_depend>nav_core</run_depend>
+    <run_depend>pluginlib</run_depend>
+    <run_depend>eigen</run_depend>
+
+
+    <export>
+        <nav_core plugin="${prefix}/recovery_plugin.xml" />
+    </export>
+
+</package>

--- a/navigation/go_forward_recovery/recovery_plugin.xml
+++ b/navigation/go_forward_recovery/recovery_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libgo_forward_recovery">
+  <class name="go_forward_recovery/GoForwardRecovery" type="go_forward_recovery::GoForwardRecovery" base_class_type="nav_core::RecoveryBehavior">
+    <description>
+      A recovery behavior that go straight along the wall.
+    </description>
+  </class>
+</library>

--- a/navigation/go_forward_recovery/src/go_forward_recovery.cpp
+++ b/navigation/go_forward_recovery/src/go_forward_recovery.cpp
@@ -90,7 +90,7 @@ void GoForwardRecovery::scanCallback(const sensor_msgs::LaserScan::ConstPtr& sca
   vel_pub = n.advertise<geometry_msgs::Twist>("cmd_vel", 10);
   scan_sub = n.subscribe("/scan", 10, &GoForwardRecovery::scanCallback, this);
   
-  std::vector<float> ranges = scan_msg->ranges;
+  std::vector<float> ranges = scan_msg->ranges;//range value [m]
   
   sub_n = 0;
   sub_flag = 1;
@@ -137,7 +137,7 @@ void GoForwardRecovery::scanCallback(const sensor_msgs::LaserScan::ConstPtr& sca
 
   //ROS_INFO("left miniranges %f", leftRange);
     
-  if (centerRange < 1 && sub_n == 0){
+  if (centerRange < 0.3){
       ROS_WARN("center warn");
       cmd_vel.angular.z = -0.5;  // Set right rotation speed
       ROS_INFO("Start of right rotation");
@@ -149,7 +149,7 @@ void GoForwardRecovery::scanCallback(const sensor_msgs::LaserScan::ConstPtr& sca
       vel_pub.publish(cmd_vel);
       sleep(2); 
   }
-  else if (rightRange < 1 && sub_n == 0){
+  else if (rightRange < 0.3){
       ROS_WARN("right warn");            
       cmd_vel.angular.z = 0.5;  // Set right rotation speed
       ROS_INFO("Start of right rotation");
@@ -161,7 +161,7 @@ void GoForwardRecovery::scanCallback(const sensor_msgs::LaserScan::ConstPtr& sca
       vel_pub.publish(cmd_vel);
       sleep(2); 
   }
-  else if (leftRange < 1 && sub_n == 0){
+  else if (leftRange < 0.3){
       ROS_WARN("left warn");
       cmd_vel.angular.z = -0.5;  // Set right rotation speed
       ROS_INFO("Start of right rotation");

--- a/navigation/go_forward_recovery/src/go_forward_recovery.cpp
+++ b/navigation/go_forward_recovery/src/go_forward_recovery.cpp
@@ -1,0 +1,156 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Copyright (c) 2017, Ryo Okazaki.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: Eitan Marder-Eppstein
+*         Ryo Okazaki
+*********************************************************************/
+#include <go_forward_recovery/go_forward_recovery.h>
+#include <pluginlib/class_list_macros.h>
+
+
+//register this planner as a RecoveryBehavior plugin
+
+PLUGINLIB_EXPORT_CLASS(go_forward_recovery::GoForwardRecovery, nav_core::RecoveryBehavior)
+
+namespace go_forward_recovery {
+GoForwardRecovery::GoForwardRecovery(): global_costmap_(NULL), local_costmap_(NULL), 
+  tf_(NULL), initialized_(false), world_model_(NULL) {} 
+
+void GoForwardRecovery::initialize(std::string name, tf2_ros::Buffer*,
+                                costmap_2d::Costmap2DROS*, costmap_2d::Costmap2DROS* local_costmap){
+  if(!initialized_){
+    name_ = name;
+    tf_ = tf_;
+    global_costmap_ = global_costmap_;
+    local_costmap_ = local_costmap;
+    world_model_ = new base_local_planner::CostmapModel(*local_costmap_->getCostmap());
+    initialized_ = true;
+  }else{
+    ROS_ERROR("You should not call initialize twice on this object, doing nothing");
+  }
+}
+
+GoForwardRecovery::~GoForwardRecovery(){
+  delete world_model_;
+}
+
+double GoForwardRecovery::null_check(double target){
+  if(!(target > 0)){
+    target = (double)RANGE_MAX;
+    //ROS_WARN("RANGE OVER");
+  }
+  return target;
+}
+
+void GoForwardRecovery::scanCallback(const sensor_msgs::LaserScan::ConstPtr& msg){
+  double center_number = (-msg->angle_min)/msg->angle_increment;
+  double center = msg->ranges[center_number];
+  double left = msg->ranges[center_number+128];
+  double right = msg->ranges[center_number-128];
+  double back_left = msg->ranges[msg->ranges.size()-1];
+
+  center = null_check(center);
+  left = null_check(left);
+  right = null_check(right);
+  back_left = null_check(back_left);
+
+  //ROS_INFO("center: [%lf], left: [%lf], right: [%lf]", center, left, right);
+  //ROS_INFO("center number: [%lf]", (-msg->angle_min)/msg->angle_increment);
+
+  if(center < 0.5){
+    ROS_WARN("center warning!!");
+    cmd_vel.linear.x = 0.0;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = -1.0;
+  }
+  if(left < 0.4){
+    ROS_WARN("left warning!!");
+    cmd_vel.linear.x = 0.0;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = -1.0;
+  }
+  if(right < 0.4){
+    ROS_WARN("right warning!!");
+    cmd_vel.linear.x = 0.0;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = 1.0;
+  }
+  if(center >=0.5 && left >= 0.4 && left < 1.0 && right >= 0.4){
+    cmd_vel.linear.x = 0.2;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = 0.0;
+  }
+  if(center >=0.5 && left >= 1.0 && right >= 0.4 && back_left < 0.35){
+    cmd_vel.linear.x = 0.2;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = 1.0;
+  }
+  if(center >=0.5 && left >= 1.0 && right >= 0.4 && back_left >= 0.35){
+    cmd_vel.linear.x = 0.2;
+    cmd_vel.linear.y = 0.0;
+    cmd_vel.angular.z = 0.0;
+  }
+
+  //ROS_INFO("x: %lf, y: %lf, z: %lf", cmd_vel.linear.x, cmd_vel.linear.y, cmd_vel.angular.z);
+  vel_pub.publish(cmd_vel);
+  ROS_INFO("sub_n: %d", sub_n);
+  sub_n++;
+  if(sub_n > 100){
+    scan_sub.shutdown();
+    sub_flag = 0;
+    return;
+  }
+}
+
+void GoForwardRecovery::runBehavior(){
+  if(!initialized_){
+    ROS_ERROR("This object must be initialized before runBehavior is called");
+    return;
+  }
+
+  ROS_WARN("Go forward recovery behavior started.");
+  sub_n = 0;
+  sub_flag = 1;
+  scan_sub = n.subscribe("/scan", 10, &GoForwardRecovery::scanCallback, this);
+  vel_pub = n.advertise<geometry_msgs::Twist>("cmd_vel", 10);
+  while(n.ok()){
+    if(sub_flag == 0){
+      return;
+    }
+  }
+}
+};

--- a/navigation/move_base/package.xml
+++ b/navigation/move_base/package.xml
@@ -41,6 +41,9 @@
     <depend>clear_costmap_recovery</depend>
     <depend>navfn</depend>
     <depend>rotate_recovery</depend>
+    
+    <build_depend>go_forward_recovery</build_depend>
+    <exec_depend>go_forward_recovery</exec_depend>
 
     <exec_depend>message_runtime</exec_depend>
 

--- a/navigation/move_base/src/move_base.cpp
+++ b/navigation/move_base/src/move_base.cpp
@@ -1123,13 +1123,7 @@ namespace move_base {
         recovery_behavior_names_.push_back("rotate_recovery");
         recovery_behaviors_.push_back(rotate);
       }
-      
-      //next, we'll load a recovery behavior ----
-      boost::shared_ptr<nav_core::RecoveryBehavior> go_forward(recovery_loader_.createInstance("go_forward_recovery/GoForwardRecovery"));
-      go_forward->initialize("go_forward_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-      recovery_behavior_names_.push_back("go_forward_recovery");
-      recovery_behaviors_.push_back(go_forward);
-      
+            
       //next, we'll load a recovery behavior that will do an aggressive reset of the costmap
       boost::shared_ptr<nav_core::RecoveryBehavior> ags_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
       ags_clear->initialize("aggressive_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);

--- a/navigation/move_base/src/move_base.cpp
+++ b/navigation/move_base/src/move_base.cpp
@@ -1123,7 +1123,13 @@ namespace move_base {
         recovery_behavior_names_.push_back("rotate_recovery");
         recovery_behaviors_.push_back(rotate);
       }
-
+      
+      //next, we'll load a recovery behavior ----
+      boost::shared_ptr<nav_core::RecoveryBehavior> go_forward(recovery_loader_.createInstance("go_forward_recovery/GoForwardRecovery"));
+      go_forward->initialize("go_forward_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+      recovery_behavior_names_.push_back("go_forward_recovery");
+      recovery_behaviors_.push_back(go_forward);
+      
       //next, we'll load a recovery behavior that will do an aggressive reset of the costmap
       boost::shared_ptr<nav_core::RecoveryBehavior> ags_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
       ags_clear->initialize("aggressive_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);

--- a/tsukuba2023/params/recovery_params.yaml
+++ b/tsukuba2023/params/recovery_params.yaml
@@ -1,4 +1,9 @@
+controller_patience: 15 #default 15
+max_planning_retries: -1 #default -1
+oscillation_timeout: 0.0 #default 0.0
+
 recovery_behaviors: [{name: aggressive_reset, type: clear_costmap_recovery/ClearCostmapRecovery},
                      #{name: simple_lead_out, type: simple_lead_out/SimpleLeadOut},
                      #{name: rotate_recovery, type: rotate_recovery/RotateRecovery},
+                     #{name: go_forward_recovery, type: go_forward_recovery/GoForwardRecovery},
                      {name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery}]


### PR DESCRIPTION
・概要
去年のつくばチャレンジや今年のIGVCで障害物が近すぎてナビゲーションが終了してしまった問題点を見て
新しくmove_baseのリカバリーができるようにします。
また、このブランチでmove_baseの走行方法の変更もしたいと思います。(直進→90回転)

・詳細
move_base.cppの  void MoveBase::loadDefaultRecoveryBehaviors() (1105行目)の関数内の書き換え
go_forward_recoveryのgo_forward_recovery.cppの書き換えで
新しくリカバリー機能を変更追加することができます。

その他
リカバリーの方法で提案があったら教えていただきたいです。

・参考
https://zaki0929.github.io/page02.html
https://qiita.com/MoriKen/items/1f1f2d1e6ef0046ec12a
